### PR TITLE
feat: issue #19 LSP integration follow-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,6 @@
 .PHONY: pkg
 pkg:
 	npm i
+	npm run check:lsp-binaries
 	npm run build
 	npx vsce package

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ See [./Contributing.md](Contributing.md)
 
 ## Release Notes
 
+### 0.7.7
+
+- Integrated Neva LSP core language feature set from `nevalang/neva` `main`:
+  - completion
+  - hover
+  - go to definition
+  - find references
+  - rename / prepare rename
+  - document symbols / outline
+  - code lens + resolve
+  - semantic tokens
+- Added packaging guard (`npm run check:lsp-binaries`) to ensure all required OS/arch LSP binaries are bundled before `vsce package`.
+- Added a release smoke-test checklist: [./docs/lsp-smoke-checklist.md](./docs/lsp-smoke-checklist.md).
+- LSP protocol tracing is now configurable with `neva.trace.server` (`off`, `messages`, `verbose`), defaulting to `off` for production.
+
 ### 0.7.6
 
 - Added missing support for `x64` platform for linux (alias for amd64)

--- a/docs/lsp-smoke-checklist.md
+++ b/docs/lsp-smoke-checklist.md
@@ -1,0 +1,49 @@
+# Neva LSP Smoke Checklist
+
+Use this checklist before publishing a new extension version that bundles updated Neva language-server binaries.
+
+## 1. Bundle check
+
+1. Build/copy all expected binaries into `bin/`:
+   - `neva-lsp-windows-arm64.exe`
+   - `neva-lsp-windows-amd64.exe`
+   - `neva-lsp-linux-arm64`
+   - `neva-lsp-linux-amd64`
+   - `neva-lsp-darwin-arm64`
+   - `neva-lsp-darwin-amd64`
+2. Run:
+
+```bash
+npm run check:lsp-binaries
+```
+
+## 2. Feature smoke test in VS Code
+
+Open a Neva workspace and verify each feature works end-to-end:
+
+- completion (entities/nodes/ports/import aliases)
+- hover
+- go to definition
+- find references
+- rename + prepare rename
+- document symbols / outline
+- code lens + resolve
+- semantic tokens (declarations/references/ports)
+
+## 3. Issue triage after verification
+
+If smoke checks pass, close or update feature issues as shipped in that release:
+
+- https://github.com/nevalang/vscode-neva/issues/8
+- https://github.com/nevalang/vscode-neva/issues/9
+- https://github.com/nevalang/vscode-neva/issues/10
+- https://github.com/nevalang/vscode-neva/issues/11
+- https://github.com/nevalang/vscode-neva/issues/12
+- https://github.com/nevalang/vscode-neva/issues/13
+- https://github.com/nevalang/vscode-neva/issues/14
+- https://github.com/nevalang/vscode-neva/issues/15
+- https://github.com/nevalang/vscode-neva/issues/16
+
+## 4. Release note requirement
+
+Document that LSP core language features are now available in the extension release that includes the updated binaries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-nevalang",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-nevalang",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "description": "VSCode extension for Neva programming language",
   "publisher": "nevalang",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "license": "MIT",
   "engines": {
     "vscode": "^1.78.0"
@@ -48,6 +48,21 @@
     "Other"
   ],
   "contributes": {
+    "configuration": {
+      "title": "Neva",
+      "properties": {
+        "neva.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "markdownDescription": "Controls LSP protocol trace logging in the Neva extension output channels."
+        }
+      }
+    },
     "languages": [
       {
         "id": "neva",
@@ -100,6 +115,7 @@
     "vscode": "^1.1.37"
   },
   "scripts": {
+    "check:lsp-binaries": "bash ./scripts/check-lsp-binaries.sh",
     "build:ts": "tsc --noEmit && node esbuild.js --production",
     "build:syntax": "js-yaml syntaxes/neva.tmLanguage.yml > syntaxes/neva.tmLanguage.json",
     "build": "npm-run-all build:*",

--- a/scripts/check-lsp-binaries.sh
+++ b/scripts/check-lsp-binaries.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${ROOT_DIR}/bin"
+
+REQUIRED_BINARIES=(
+  "neva-lsp-windows-arm64.exe"
+  "neva-lsp-windows-amd64.exe"
+  "neva-lsp-linux-arm64"
+  "neva-lsp-linux-amd64"
+  "neva-lsp-darwin-arm64"
+  "neva-lsp-darwin-amd64"
+)
+
+if [[ ! -d "${BIN_DIR}" ]]; then
+  echo "error: missing ${BIN_DIR}. Build/copy Neva LSP binaries first."
+  exit 1
+fi
+
+missing=0
+for binary in "${REQUIRED_BINARIES[@]}"; do
+  binary_path="${BIN_DIR}/${binary}"
+
+  if [[ ! -f "${binary_path}" ]]; then
+    echo "error: missing binary: ${binary_path}"
+    missing=1
+    continue
+  fi
+
+  if [[ "${binary}" != *.exe && ! -x "${binary_path}" ]]; then
+    echo "error: binary is not executable: ${binary_path}"
+    missing=1
+  fi
+
+done
+
+if [[ "${missing}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "ok: all required LSP binaries are present in ${BIN_DIR}"

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -9,6 +9,8 @@ import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 export const clientId = "nevaLSPClient";
 export const clientName = "Neva LSP Client";
 
+type TraceMode = "off" | "messages" | "verbose";
+
 export function setupLsp(
   context: ExtensionContext,
   isDebug: boolean
@@ -66,7 +68,17 @@ export function setupLsp(
     },
   });
 
-  client.setTrace(Trace.Verbose);
+  const traceMode = workspace
+    .getConfiguration("neva")
+    .get<TraceMode>("trace.server", isDebug ? "verbose" : "off");
+
+  client.setTrace(
+    {
+      off: Trace.Off,
+      messages: Trace.Messages,
+      verbose: Trace.Verbose,
+    }[traceMode]
+  );
 
   client
     .start()


### PR DESCRIPTION
## Summary
- make LSP trace level configurable via `neva.trace.server` and default to `off` in production
- add `check:lsp-binaries` preflight script and wire it into `make pkg`
- add a dedicated LSP smoke checklist and release-note entry for the integration
- bump extension version to 0.7.7

## Validation
- `npm run build:ts`
- `npm run check:lsp-binaries` (expected to fail until `bin/` is populated)

Closes #19
