### PR TITLE
CI: build Neva LSP binaries and package VSIX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       neva_ref:
-        description: "nevalang/neva ref (branch, tag or SHA)"
+        description: "nevalang/neva-lsp ref (branch, tag or SHA)"
         required: false
         default: "main"
 
@@ -66,10 +66,10 @@ jobs:
             echo "value=main" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout nevalang/neva
+      - name: Checkout nevalang/neva-lsp
         uses: actions/checkout@v4
         with:
-          repository: nevalang/neva
+          repository: nevalang/neva-lsp
           ref: ${{ steps.neva-ref.outputs.value }}
           path: neva-src
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you use VSCode, you can use `Run Extension` debug task. This will allow to sp
 
 After you make changes to LSP-server, make sure you compile binaries for all supported platforms and put them into `bin` directory in this repo. When you'll use `make pkg` the `vsce` will pack those binaries into vscode extension archive.
 
-In CI, LSP binaries are built from `nevalang/neva` directly (see `.github/workflows/ci.yml`) and downloaded into `bin/` before packaging. No git submodule is required.
+In CI, LSP binaries are built from `nevalang/neva-lsp` directly (see `.github/workflows/ci.yml`) and downloaded into `bin/` before packaging. No git submodule is required.
 
 ### Testing
 


### PR DESCRIPTION
## Summary\n- add GitHub Actions CI workflow to build all required  binaries from  (darwin/linux/windows x amd64/arm64)\n- upload each built binary as an artifact and then assemble them into  for extension packaging\n- build and package the extension (
added 567 packages, and audited 568 packages in 16s

110 packages are looking for funding
  run `npm fund` for details

34 vulnerabilities (2 low, 14 moderate, 11 high, 7 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details., 
> vscode-nevalang@0.7.6 build
> npm-run-all build:*


> vscode-nevalang@0.7.6 build:ts
> tsc --noEmit && node esbuild.js --production

[watch] build started
[watch] build finished

> vscode-nevalang@0.7.6 build:syntax
> js-yaml syntaxes/neva.tmLanguage.yml > syntaxes/neva.tmLanguage.json,  DONE  Packaged: /Users/emil/.codex/worktrees/f122/vscode-neva/vscode-nevalang-0.7.6.vsix (18 files, 359.42KB)) and upload  as CI artifact\n- document CI behavior in CONTRIBUTING: no git submodule required for LSP\n\n## Why\nThis makes extension CI/CD self-contained: it can build the exact LSP binaries needed for release packaging without relying on manual local copying into .\n\n## Notes\n- workflow supports manual dispatch with optional  input to build against a specific  branch/tag/SHA\n- no version bump or publishing changes included\n\n## Verification\n- local: 
> vscode-nevalang@0.7.6 build
> npm-run-all build:*


> vscode-nevalang@0.7.6 build:ts
> tsc --noEmit && node esbuild.js --production

[watch] build started
[watch] build finished

> vscode-nevalang@0.7.6 build:syntax
> js-yaml syntaxes/neva.tmLanguage.yml > syntaxes/neva.tmLanguage.json passes\n