### PR TITLE
CI: build Neva LSP binaries and package VSIX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
       - master
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       neva_ref:
@@ -139,3 +142,30 @@ jobs:
           name: vscode-neva-vsix
           path: '*.vsix'
           if-no-files-found: error
+
+  publish-marketplace:
+    name: Publish to VS Code Marketplace
+    needs:
+      - build-extension
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vscode-neva-vsix
+          path: dist
+
+      - name: Publish to Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          test -n "$VSCE_PAT"
+          VSIX_FILE=$(ls -1 dist/*.vsix | head -n 1)
+          npx vsce publish --packagePath "$VSIX_FILE" -p "$VSCE_PAT"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ If you use VSCode, you can use `Run Extension` debug task. This will allow to sp
 After you make changes to LSP-server, make sure you compile binaries for all supported platforms and put them into `bin` directory in this repo. When you'll use `make pkg` the `vsce` will pack those binaries into vscode extension archive.
 
 In CI, LSP binaries are built from `nevalang/neva-lsp` directly (see `.github/workflows/ci.yml`) and downloaded into `bin/` before packaging. No git submodule is required.
+Marketplace publishing is release-only: the workflow publishes to VS Code Marketplace on `release.published` using the `VSCE_PAT` repository secret.
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to build all required neva-lsp binaries from nevalang/neva (darwin/linux/windows x amd64/arm64)
- upload each built binary as an artifact and then assemble them into bin/ for extension packaging
- build and package the extension (npm ci, npm run build, npx vsce package) and upload .vsix as CI artifact
- document CI behavior in CONTRIBUTING: no git submodule required for LSP

## Why
This makes extension CI/CD self-contained: it can build the exact LSP binaries needed for release packaging without relying on manual local copying into bin/.

## Notes
- workflow supports manual dispatch with optional neva_ref input to build against a specific nevalang/neva branch/tag/SHA
- no version bump or publishing changes included

## Verification
- local: npm run build passes
