### PR TITLE
CI: remove duplicate release publishing from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
       - master
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       neva_ref:
@@ -142,30 +139,3 @@ jobs:
           name: vscode-neva-vsix
           path: '*.vsix'
           if-no-files-found: error
-
-  publish-marketplace:
-    name: Publish to VS Code Marketplace
-    needs:
-      - build-extension
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: vscode-neva-vsix
-          path: dist
-
-      - name: Publish to Marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: |
-          test -n "$VSCE_PAT"
-          VSIX_FILE=$(ls -1 dist/*.vsix | head -n 1)
-          npx vsce publish --packagePath "$VSIX_FILE" -p "$VSCE_PAT"


### PR DESCRIPTION
## Summary
- remove release trigger from `.github/workflows/ci.yml`
- remove marketplace publish job from `ci.yml`

## Why
`release-marketplace.yml` already handles Marketplace publishing on release. Keeping release publishing logic in both workflows can lead to duplicate publish attempts and harder-to-reason release automation.

## Result
- CI remains for PR/push/manual build verification and VSIX artifact generation.
- Release publish stays single-source in `release-marketplace.yml`.
