### PR TITLE
chore: bump version to 0.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-nevalang",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-nevalang",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "description": "VSCode extension for Neva programming language",
   "publisher": "nevalang",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "license": "MIT",
   "engines": {
     "vscode": "^1.78.0"


### PR DESCRIPTION
## Summary
- bump extension version from 0.7.7 to 0.7.8 in npm manifests

## Changed files
- package.json
- package-lock.json

This is a release-prep version bump only.
