### PR TITLE
Add textual/visual mode toggle buttons for Neva editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
       {
         "command": "neva.runMain",
         "title": "Neva: Run Main"
+      },
+      {
+        "command": "neva.openTextualMode",
+        "title": "Neva: Open Textual Mode"
+      },
+      {
+        "command": "neva.openVisualMode",
+        "title": "Neva: Open Visual Mode"
       }
     ],
     "languages": [
@@ -100,7 +108,21 @@
         "language": "neva",
         "path": "./snippets/neva.json"
       }
-    ]
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "neva.openTextualMode",
+          "when": "neva.activeEditorIsNeva && neva.editorMode != textual",
+          "group": "navigation@10"
+        },
+        {
+          "command": "neva.openVisualMode",
+          "when": "neva.activeEditorIsNeva && neva.editorMode != visual",
+          "group": "navigation@11"
+        }
+      ]
+    }
   },
   "activationEvents": [
     "workspaceContains:neva.yml",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,10 +5,14 @@ import {
   CodeLensProvider,
   CancellationToken,
   ProviderResult,
+  Disposable,
+  Event,
+  EventEmitter,
   ExtensionContext,
   languages,
   Range,
   TextDocument,
+  TextEditor,
   Uri,
   window,
   workspace,
@@ -21,7 +25,15 @@ let runTerminal = undefined as ReturnType<typeof window.createTerminal> | undefi
 let runTerminalCwd = "";
 
 const runMainCommandId = "neva.runMain";
+const setTextualModeCommandId = "neva.openTextualMode";
+const setVisualModeCommandId = "neva.openVisualMode";
 const mainDefRegex = /^[ \t]*(pub[ \t]+)?def[ \t]+Main\b/gm;
+const nevaEditorModeContextKey = "neva.editorMode";
+const nevaEditorContextKey = "neva.activeEditorIsNeva";
+
+type NevaEditorMode = "textual" | "visual";
+let currentMode: NevaEditorMode = "textual";
+const onDidChangeEditorModeEmitter = new EventEmitter<NevaEditorMode>();
 
 function provideRunCodeLenses(document: TextDocument) {
   const text = document.getText();
@@ -68,6 +80,23 @@ function runNeva(uri?: Uri) {
   runTerminal.sendText("neva run .", true);
 }
 
+async function updateActiveEditorContext(editor: TextEditor | undefined) {
+  const isNeva = editor?.document.languageId === "neva";
+  await commands.executeCommand("setContext", nevaEditorContextKey, isNeva);
+}
+
+async function setEditorMode(mode: NevaEditorMode) {
+  currentMode = mode;
+  await commands.executeCommand("setContext", nevaEditorModeContextKey, mode);
+  onDidChangeEditorModeEmitter.fire(mode);
+
+  if (mode === "visual") {
+    void window.showInformationMessage(
+      "Neva visual mode is not implemented yet. This button is a placeholder for the upcoming visual editor API."
+    );
+  }
+}
+
 const runMainCodeLensProvider = {
   provideCodeLenses(
     document: TextDocument,
@@ -86,15 +115,38 @@ export async function activate(context: ExtensionContext) {
     window.showWarningMessage(message);
   });
 
+  await setEditorMode("textual");
+  await updateActiveEditorContext(window.activeTextEditor);
+
   context.subscriptions.push(
     commands.registerCommand(runMainCommandId, runNeva),
+    commands.registerCommand(setTextualModeCommandId, () => setEditorMode("textual")),
+    commands.registerCommand(setVisualModeCommandId, () => setEditorMode("visual")),
+    commands.registerCommand("neva.getEditorMode", () => currentMode),
+    commands.registerCommand("neva.onDidChangeEditorMode", (listener: (mode: NevaEditorMode) => void): Disposable =>
+      onDidChangeEditorModeEmitter.event(listener)
+    ),
+    window.onDidChangeActiveTextEditor((editor) => {
+      void updateActiveEditorContext(editor);
+    }),
     languages.registerCodeLensProvider(
       { language: "neva", scheme: "file" },
       runMainCodeLensProvider
     )
   );
+
+  return getApi();
 }
 
 export function deactivate(): Thenable<void> | undefined {
+  onDidChangeEditorModeEmitter.dispose();
   return lspClient && lspClient.stop();
+}
+
+export function getApi() {
+  return {
+    getEditorMode: () => currentMode,
+    onDidChangeEditorMode: onDidChangeEditorModeEmitter.event as Event<NevaEditorMode>,
+    setEditorMode,
+  };
 }


### PR DESCRIPTION
## Summary
- add editor title toggle commands for Textual/Visual modes in `.neva` files
- track active Neva editor + current mode via VS Code context keys
- expose a minimal extension API surface (`getEditorMode`, `setEditorMode`, `onDidChangeEditorMode`) as a starting point for visual editor integration

## Verification
- npm run build
- open a `.neva` file in Extension Development Host
- verify editor title shows Visual button by default
- click Visual and confirm placeholder message + button flips to Textual
- click Textual and confirm button flips back to Visual

Closes #26
