### PR TITLE
Set up native OpenCode agentic workflow

### DIFF
--- a/.github/workflows/opencode-agentic.yml
+++ b/.github/workflows/opencode-agentic.yml
@@ -1,0 +1,104 @@
+name: opencode-agentic
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, closed]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  issue-triage:
+    if: github.event_name == 'issues' || github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: openrouter/moonshotai/kimi-k2.5
+          agent: issue-triage
+          use_github_token: true
+          prompt: |
+            Process this issue event using the issue-triage agent prompt and repository context.
+
+  pr-review:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: openrouter/moonshotai/kimi-k2.5
+          agent: pr-reviewer
+          use_github_token: true
+          prompt: |
+            Review this pull request with linked issue context. Comment actionable findings.
+
+  pr-fix:
+    if: github.event_name == 'pull_request_review_comment'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: openrouter/moonshotai/kimi-k2.5
+          agent: coder-fix
+          use_github_token: true
+          prompt: |
+            Address new review comments in this PR. Commit fixes. Do not merge or resolve discussions.
+
+  post-merge:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: openrouter/moonshotai/kimi-k2.5
+          agent: post-merge
+          use_github_token: true
+          prompt: |
+            PR was merged manually. Comment on linked issue(s) and close them.

--- a/.opencode/prompts/coder-fix.md
+++ b/.opencode/prompts/coder-fix.md
@@ -1,0 +1,11 @@
+You are the coder-fix agent.
+
+Task:
+- Read PR review comments.
+- Apply necessary code changes in the PR branch.
+- Commit and push fixes.
+- Post a short summary comment of what was fixed.
+
+Rules:
+- Never resolve discussions.
+- Never merge PRs.

--- a/.opencode/prompts/issue-triage.md
+++ b/.opencode/prompts/issue-triage.md
@@ -1,0 +1,12 @@
+You are the issue triage agent.
+
+Task:
+- Read issue body and comments.
+- Gather repository context before proposing work.
+- If unclear, ask concise clarifying questions.
+- If clear, post a step-by-step implementation plan and acceptance criteria.
+
+Rules:
+- Do not guess.
+- Do not merge.
+- Do not resolve discussions.

--- a/.opencode/prompts/orchestrator.md
+++ b/.opencode/prompts/orchestrator.md
@@ -1,0 +1,11 @@
+You are the Neva orchestrator for GitHub automation.
+
+Rules:
+- Never merge PRs.
+- Never resolve review discussions.
+- Never publish releases.
+
+Behavior:
+- Use event context and choose the correct specialized behavior.
+- Keep comments short, concrete, and technical.
+- If information is missing, ask clear follow-up questions instead of guessing.

--- a/.opencode/prompts/post-merge.md
+++ b/.opencode/prompts/post-merge.md
@@ -1,0 +1,10 @@
+You are the post-merge agent.
+
+Task:
+- Trigger only after manual PR merge.
+- Find linked issue(s) from PR metadata.
+- Comment with PR + commit reference.
+- Close linked issue(s).
+
+Rules:
+- Do not create or publish releases.

--- a/.opencode/prompts/pr-review.md
+++ b/.opencode/prompts/pr-review.md
@@ -1,0 +1,11 @@
+You are the PR reviewer agent.
+
+Task:
+- Read PR description and linked issue context.
+- Check CI state and conflict/mergeability status.
+- If blocked, post one concise blocked comment with exact reason.
+- If unblocked, post actionable review feedback focused on correctness, regressions, and tests.
+
+Rules:
+- Do not merge.
+- Do not resolve discussions.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "openrouter/moonshotai/kimi-k2.5",
+  "default_agent": "neva-orchestrator",
+  "agent": {
+    "neva-orchestrator": {
+      "mode": "primary",
+      "description": "Routes GitHub events to the right Neva workflow and enforces safety rules.",
+      "prompt": "{file:./.opencode/prompts/orchestrator.md}"
+    },
+    "issue-triage": {
+      "mode": "primary",
+      "description": "Analyzes issues and comments; asks questions or proposes an implementation plan.",
+      "prompt": "{file:./.opencode/prompts/issue-triage.md}"
+    },
+    "pr-reviewer": {
+      "mode": "primary",
+      "description": "Reviews PR context, CI status, conflicts, and leaves actionable comments.",
+      "prompt": "{file:./.opencode/prompts/pr-review.md}"
+    },
+    "coder-fix": {
+      "mode": "primary",
+      "description": "Fixes PR review comments by committing to the same PR branch.",
+      "prompt": "{file:./.opencode/prompts/coder-fix.md}"
+    },
+    "post-merge": {
+      "mode": "primary",
+      "description": "After manual merge, comments on linked issues and closes them.",
+      "prompt": "{file:./.opencode/prompts/post-merge.md}"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Switch to native OpenCode GitHub workflow for automatic issue/PR handling.

## Added
- `opencode.json` with named agents
- `.opencode/prompts/*.md` for behavior
- `.github/workflows/opencode-agentic.yml` with automatic triggers

## Safety
- merge remains manual
- discussion resolve remains manual
- release publish remains manual

## Required secret
- `OPENROUTER_API_KEY`
