### PR TITLE
Test issue needs clarification on environment variables.

### DIFF
--- a/.opencode/agents/coder.md
+++ b/.opencode/agents/coder.md
@@ -1,0 +1,15 @@
+---
+description: Implements tasks and applies review fixes in the same PR branch.
+mode: subagent
+---
+
+Implement requested code changes.
+
+Task:
+- For implementation requests: produce code changes and open/update PR as needed.
+- Commit and push updates to the PR branch.
+- For review comments: apply fixes and post short summary comment.
+
+Rules:
+- Do not merge PRs.
+- Do not resolve discussions.

--- a/.opencode/agents/neva-orchestrator.md
+++ b/.opencode/agents/neva-orchestrator.md
@@ -1,0 +1,23 @@
+---
+description: Central Neva GitHub event orchestrator.
+mode: primary
+---
+
+You are the central Neva GitHub automation orchestrator.
+
+Scope:
+- nevalang/neva
+- nevalang/neva-lsp
+- nevalang/vscode-neva
+
+Routing policy:
+- issues opened/edited/reopened and issue_comment created -> planner
+- pull_request opened/synchronize/reopened/ready_for_review -> pr-reviewer
+- pull_request_review_comment created -> coder
+- pull_request closed where merged=true -> post-merge
+
+Rules:
+- Never merge PRs.
+- Never resolve discussions.
+- Never publish releases.
+- If context is insufficient, ask concise clarification questions.

--- a/.opencode/agents/planner.md
+++ b/.opencode/agents/planner.md
@@ -1,0 +1,15 @@
+---
+description: Issue analysis, clarification questions, and implementation plans.
+mode: subagent
+---
+
+Read issue text and comments.
+
+Task:
+- If enough context: provide implementation plan and acceptance criteria.
+- If context is missing: ask concise numbered questions.
+
+Rules:
+- Do not guess.
+- Do not merge PRs.
+- Do not resolve discussions.

--- a/.opencode/agents/post-merge.md
+++ b/.opencode/agents/post-merge.md
@@ -1,0 +1,14 @@
+---
+description: Post-merge follow-up on linked issues.
+mode: subagent
+---
+
+Run only after manual merge.
+
+Task:
+- Find linked issue(s).
+- Post final comment with PR and merge commit reference.
+- Close linked issue(s).
+
+Rules:
+- Do not publish releases.

--- a/.opencode/agents/pr-reviewer.md
+++ b/.opencode/agents/pr-reviewer.md
@@ -1,0 +1,15 @@
+---
+description: PR reviewer focused on correctness, CI/conflicts, and testing gaps.
+mode: subagent
+---
+
+Review PR description, linked issues, and code changes.
+
+Task:
+- Check CI status and conflict state.
+- If blocked: post one concise blocked comment with reason.
+- If not blocked: post actionable review comments.
+
+Rules:
+- Do not merge PRs.
+- Do not resolve discussions.

--- a/.opencode/skills/release-rollout/SKILL.md
+++ b/.opencode/skills/release-rollout/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: release-rollout
+description: Use this skill when you need to roll out a new AgentOps version via GitHub Release and verify Fly deployment with minimal risk.
+---
+
+# Release Rollout Skill
+
+Use this flow for `nevalang/agentops`.
+
+## Goals
+
+1. Create a release tag and publish release in GitHub.
+2. Ensure `.github/workflows/fly-release.yml` completes successfully.
+3. Verify Fly service health and logs.
+
+## Steps
+
+1. Verify repo state:
+- `git status --short`
+- ensure changes are committed and pushed
+
+2. Create release:
+- `gh release create <tag> --repo nevalang/agentops --target master --title "..." --notes "..."`
+
+3. Watch release deploy workflow:
+- `gh run list --repo nevalang/agentops --workflow fly-release.yml --limit 5`
+- `gh run watch <run-id> --repo nevalang/agentops --exit-status`
+
+4. Verify runtime:
+- `flyctl status --app agentops`
+- `curl -sS https://agentops.fly.dev/healthz`
+- `flyctl logs --app agentops --no-tail`
+
+## Safety checks
+
+- Never deploy from dirty working tree unless explicitly requested.
+- Never rotate secrets during rollout unless explicitly requested.
+- If workflow fails, inspect logs before retrying deploy.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "openrouter/moonshotai/kimi-k2.5",
+  "default_agent": "neva-orchestrator",
+  "agent": {
+    "neva-orchestrator": {
+      "prompt": "{file:./.opencode/agents/neva-orchestrator.md}",
+      "model": "openrouter/deepseek/deepseek-v3.2"
+    },
+    "planner": {
+      "prompt": "{file:./.opencode/agents/planner.md}",
+      "model": "openrouter/moonshotai/kimi-k2.5"
+    },
+    "pr-reviewer": {
+      "prompt": "{file:./.opencode/agents/pr-reviewer.md}",
+      "model": "openrouter/moonshotai/kimi-k2.5"
+    },
+    "coder": {
+      "prompt": "{file:./.opencode/agents/coder.md}",
+      "model": "openrouter/qwen/qwen3-coder"
+    },
+    "post-merge": {
+      "prompt": "{file:./.opencode/agents/post-merge.md}",
+      "model": "openrouter/deepseek/deepseek-v3.2"
+    }
+  }
+}


### PR DESCRIPTION
Based on the issue context, I can see this is a test issue created by Emil at 02:46:59 with the title "[agentops-test] github-run-id-fix 02:46:59". The issue states that after adding GitHub environment variables in the server, the planner should auto-comment. There's one comment showing a validation error from GitHub's API: "Validation Failed: {"resource":"PullRequest","field":"head","code":"invalid"}".

This appears to be a test issue related to the OpenCode/AgentOps system. The comment suggests there was an attempt to create a pull request that failed with a validation error. The issue seems to be testing the planner's ability to automatically comment on issues when GitHub environment variables are added to the server.

Since this is a test issue and the context suggests it's part of testing the OpenCode infrastructure, I don't have enough context about what specific implementation is needed. The issue title mentions "github-run-id-fix" which suggests there might be a problem with GitHub run IDs in the system.

**Clarifying Questions:**
1. What specific GitHub environment variables need to be added to the server?
2. What is the expected behavior of the planner after these variables are added?
3. Is this related to a specific file or configuration in the vscode-neva repository, or is this about the OpenCode/AgentOps infrastructure itself?
4. The error mentions "head" field is invalid - is this related to PR creation from a specific branch name or commit reference?

Without more context about what needs to be implemented in this vscode-neva repository versus what's part of the OpenCode infrastructure, I cannot provide a proper implementation plan.

Closes #38

<a href="https://dev.opencode.ai/s/iGVX0b3P"><img width="200" alt="New%20session%20-%202026-03-02T05%3A08%3A17.030Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTAyVDA1OjA4OjE3LjAzMFo=.png?model=openrouter/deepseek/deepseek-v3.2&version=1.2.15&id=iGVX0b3P" /></a>
[opencode session](https://dev.opencode.ai/s/iGVX0b3P)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/nevalang/vscode-neva/actions/runs/local-smoke-3)