### PR TITLE
Build LSP from Neva Tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       neva_ref:
-        description: "nevalang/neva-tools ref (branch, tag or SHA)"
+        description: "nevalang/neva-tools ref override (branch, tag or SHA)"
         required: false
         default: ""
 
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   NODE_VERSION: "20"
+  NEVA_TOOLS_REF: 57dfecce4c11accb32c3a6bb471f17850dbe1796
 
 jobs:
   build-lsp-binaries:
@@ -62,10 +63,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.neva_ref }}" ]; then
             echo "value=${{ github.event.inputs.neva_ref }}" >> "$GITHUB_OUTPUT"
-          elif git ls-remote --exit-code --heads https://github.com/nevalang/neva-tools refs/heads/main >/dev/null 2>&1; then
-            echo "value=main" >> "$GITHUB_OUTPUT"
           else
-            echo "value=master" >> "$GITHUB_OUTPUT"
+            echo "value=${NEVA_TOOLS_REF}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout nevalang/neva-tools
@@ -111,6 +110,24 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
+      - name: Checkout Neva Tools for the shared visual editor
+        uses: actions/checkout@v4
+        with:
+          repository: nevalang/neva-tools
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.neva_ref || env.NEVA_TOOLS_REF }}
+          path: neva-tools
+
+      - name: Build shared visual-editor WebView bundle
+        working-directory: neva-tools/web
+        run: |
+          npm ci
+          npm run build:vscode
+
+      - name: Copy shared visual-editor bundle
+        run: |
+          mkdir -p dist
+          cp -R neva-tools/dist/webview dist/webview
+
       - name: Download LSP binary artifacts
         uses: actions/download-artifact@v4
         with:
@@ -130,6 +147,9 @@ jobs:
           chmod +x bin/neva-lsp-darwin-arm64
           chmod +x bin/neva-lsp-linux-amd64
           chmod +x bin/neva-lsp-linux-arm64
+
+      - name: Check packaged LSP binaries
+        run: npm run check:lsp-binaries
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       neva_ref:
-        description: "nevalang/neva-lsp ref (branch, tag or SHA)"
+        description: "nevalang/neva-tools ref (branch, tag or SHA)"
         required: false
         default: ""
 
@@ -57,21 +57,21 @@ jobs:
       - name: Checkout extension repository
         uses: actions/checkout@v4
 
-      - name: Resolve neva ref
+      - name: Resolve Neva Tools ref
         id: neva-ref
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.neva_ref }}" ]; then
             echo "value=${{ github.event.inputs.neva_ref }}" >> "$GITHUB_OUTPUT"
-          elif git ls-remote --exit-code --heads https://github.com/nevalang/neva-lsp refs/heads/main >/dev/null 2>&1; then
+          elif git ls-remote --exit-code --heads https://github.com/nevalang/neva-tools refs/heads/main >/dev/null 2>&1; then
             echo "value=main" >> "$GITHUB_OUTPUT"
           else
             echo "value=master" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout nevalang/neva-lsp
+      - name: Checkout nevalang/neva-tools
         uses: actions/checkout@v4
         with:
-          repository: nevalang/neva-lsp
+          repository: nevalang/neva-tools
           ref: ${{ steps.neva-ref.outputs.value }}
           path: neva-src
 
@@ -84,10 +84,7 @@ jobs:
         run: |
           mkdir -p bin
           cd neva-src
-          LSP_ENTRY=./cmd/lsp
-          if [ ! -d "$LSP_ENTRY" ]; then
-            LSP_ENTRY=.
-          fi
+          LSP_ENTRY=./cmd/neva-lsp
           GOOS=${{ matrix.target.goos }} GOARCH=${{ matrix.target.goarch }} \
             go build -ldflags="-s -w" -o "../bin/${{ matrix.target.output }}" "$LSP_ENTRY"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   NODE_VERSION: "20"
-  NEVA_TOOLS_REF: 57dfecce4c11accb32c3a6bb471f17850dbe1796
+  NEVA_TOOLS_REF: 7e66e889bc1e255dc941d98697cf58365db10cc3
 
 jobs:
   build-lsp-binaries:

--- a/.github/workflows/release-marketplace.yml
+++ b/.github/workflows/release-marketplace.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  NEVA_TOOLS_REF: 57dfecce4c11accb32c3a6bb471f17850dbe1796
+  NEVA_TOOLS_REF: 7e66e889bc1e255dc941d98697cf58365db10cc3
 
 jobs:
   publish-marketplace:

--- a/.github/workflows/release-marketplace.yml
+++ b/.github/workflows/release-marketplace.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       neva_ref:
-        description: "nevalang/neva-tools ref (branch, tag or SHA)"
+        description: "nevalang/neva-tools ref override (branch, tag or SHA)"
         required: false
         default: ""
 
@@ -16,6 +16,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  NEVA_TOOLS_REF: 57dfecce4c11accb32c3a6bb471f17850dbe1796
 
 jobs:
   publish-marketplace:
@@ -37,10 +40,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.neva_ref }}" ]; then
             echo "value=${{ github.event.inputs.neva_ref }}" >> "$GITHUB_OUTPUT"
-          elif git ls-remote --exit-code --heads https://github.com/nevalang/neva-tools refs/heads/main >/dev/null 2>&1; then
-            echo "value=main" >> "$GITHUB_OUTPUT"
           else
-            echo "value=master" >> "$GITHUB_OUTPUT"
+            echo "value=${NEVA_TOOLS_REF}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout neva-tools
@@ -54,6 +55,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: neva-tools/go.mod
+
+      - name: Build shared visual-editor WebView bundle
+        working-directory: neva-tools/web
+        run: |
+          npm ci
+          npm run build:vscode
+
+      - name: Copy shared visual-editor bundle
+        run: |
+          mkdir -p dist
+          cp -R neva-tools/dist/webview dist/webview
 
       - name: Validate required secret
         shell: bash
@@ -73,6 +85,9 @@ jobs:
           chmod +x bin/neva-lsp-darwin-arm64
           chmod +x bin/neva-lsp-linux-amd64
           chmod +x bin/neva-lsp-linux-arm64
+
+      - name: Check packaged LSP binaries
+        run: npm run check:lsp-binaries
 
       - name: Verify release tag matches package version
         if: github.event_name == 'release'

--- a/.github/workflows/release-marketplace.yml
+++ b/.github/workflows/release-marketplace.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       neva_ref:
-        description: "nevalang/neva-lsp ref (branch, tag or SHA)"
+        description: "nevalang/neva-tools ref (branch, tag or SHA)"
         required: false
         default: ""
 
@@ -32,28 +32,28 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Resolve neva ref
+      - name: Resolve Neva Tools ref
         id: neva-ref
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.neva_ref }}" ]; then
             echo "value=${{ github.event.inputs.neva_ref }}" >> "$GITHUB_OUTPUT"
-          elif git ls-remote --exit-code --heads https://github.com/nevalang/neva-lsp refs/heads/main >/dev/null 2>&1; then
+          elif git ls-remote --exit-code --heads https://github.com/nevalang/neva-tools refs/heads/main >/dev/null 2>&1; then
             echo "value=main" >> "$GITHUB_OUTPUT"
           else
             echo "value=master" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout neva-lsp
+      - name: Checkout neva-tools
         uses: actions/checkout@v4
         with:
-          repository: nevalang/neva-lsp
+          repository: nevalang/neva-tools
           ref: ${{ steps.neva-ref.outputs.value }}
-          path: neva-lsp
+          path: neva-tools
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: neva-lsp/go.mod
+          go-version-file: neva-tools/go.mod
 
       - name: Validate required secret
         shell: bash
@@ -64,8 +64,8 @@ jobs:
             exit 1
           fi
 
-      - name: Build LSP binaries from neva-lsp
-        run: ./scripts/release/build-lsp-from-neva-main.sh ./neva-lsp ./bin
+      - name: Build LSP binaries from Neva Tools
+        run: ./scripts/release/build-lsp-from-neva-tools.sh ./neva-tools ./bin
 
       - name: Ensure executable bits for unix binaries
         run: |

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,5 +7,6 @@ syntaxes/neva.tmLanguage.yml
 .gitignore
 .vscodeignore
 webview
+neva-tools
 tsconfig.json
 package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Follow these instructions when working in this repository.
 1. Use `gh` CLI for GitHub context (issues/PRs). Fall back to web browsing only when `gh` is insufficient.
 2. Prefer small, incremental changes. After each feature implementation, report back with what changed and how to verify.
 3. Do **not** push to `main` or release a new extension version without explicit approval.
-4. The Neva compiler lives in `/Users/emil/projects/neva` (read-only). The LSP server lives in `nevalang/neva-lsp` and should be sourced from its remote `main` when updating binaries.
+4. The Neva compiler lives in `/Users/emil/projects/neva` (read-only). Neva tools live in `nevalang/neva-tools`; source the LSP from its remote `main` when updating binaries.
 5. Assume the current Neva language is `main` (ahead of v0.34); deferred connections are **not** supported and should not be encoded in the extension (syntax highlighting, docs, etc.).
 6. Keep the extension compatible with VS Code stable.
 
@@ -26,7 +26,7 @@ Follow these instructions when working in this repository.
 
 ## 4) LSP Binaries
 
-- LSP server source is in `https://github.com/nevalang/neva-lsp` (`main` branch).
+- LSP server source is in `https://github.com/nevalang/neva-tools` (`main` branch), at `cmd/neva-lsp`.
 - If updating LSP binaries, build for all supported OS/arch and place them under `bin/`.
 - The extension selects a binary by platform/arch in `src/lsp.ts`.
 
@@ -39,4 +39,4 @@ Follow these instructions when working in this repository.
 
 - Issues: https://github.com/nevalang/vscode-neva/issues
 - Neva compiler repo (main): `/Users/emil/projects/neva`
-- Neva LSP repo: https://github.com/nevalang/neva-lsp
+- Neva Tools repo: https://github.com/nevalang/neva-tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 Extension consist of 3 parts:
 
-1. Language server (in `nevalang/neva-lsp` repo)
+1. Language server (in `nevalang/neva-tools`, at `cmd/neva-lsp`)
 2. VSCode extension in `src`
 3. Syntax highlighting grammar under `syntaxes` directory
 
@@ -16,9 +16,9 @@ If you use VSCode, you can use `Run Extension` debug task. This will allow to sp
 
 ### LSP
 
-After you make changes to LSP-server in `nevalang/neva-lsp`, make sure you compile binaries for all supported platforms and put them into `bin` directory in this repo. When you'll use `make pkg` the `vsce` will pack those binaries into vscode extension archive.
+After you make changes to the LSP in `nevalang/neva-tools`, make sure you compile binaries for all supported platforms and put them into `bin` directory in this repo. When you'll use `make pkg` the `vsce` will pack those binaries into vscode extension archive.
 
-In CI, LSP binaries are built from `nevalang/neva-lsp` directly (see `.github/workflows/ci.yml`) and downloaded into `bin/` before packaging. No git submodule is required.
+In CI, LSP binaries are built from `nevalang/neva-tools` directly (see `.github/workflows/ci.yml`) and downloaded into `bin/` before packaging. No git submodule is required.
 Marketplace publishing is release-only: the workflow publishes to VS Code Marketplace on `release.published` using the `VSCE_PAT` repository secret.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The repository includes automated publishing on GitHub Release:
 
 - Workflow: `.github/workflows/release-marketplace.yml`
 - Trigger: published GitHub release (or manual `workflow_dispatch`)
-- Behavior: fetches `nevalang/neva-lsp` (prefers `main`, falls back to `master`), rebuilds all LSP binaries, builds and packages extension, publishes to Marketplace.
+- Behavior: fetches `nevalang/neva-tools` (prefers `main`, falls back to `master`), rebuilds `cmd/neva-lsp` for all targets, builds and packages extension, publishes to Marketplace.
 
 Required secret in GitHub repository settings:
 
@@ -78,7 +78,7 @@ Release flow:
 
 ### 0.7.8
 
-- Integrated Neva LSP core language feature set from `nevalang/neva-lsp`:
+- Integrated Neva LSP core language feature set from `nevalang/neva-tools`:
   - completion
   - hover
   - go to definition

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Basic snippets are available for core language constructs:
 - `union`
 - `const`
 
-### Visual Editor (WIP)
+### Visual Editor
 
-Currently disabled due to massive changes in the language. You can see the source code in the `webview` directory.
+`Neva: Open Visual Mode` opens the same read-only React editor as `neva-view`, directly beside the source file. It talks to the already-running language server, so it needs no separate HTTP server or browser process. Saving a `.neva` file refreshes its projection.
 
 ## Contributing
 
@@ -56,7 +56,7 @@ The repository includes automated publishing on GitHub Release:
 
 - Workflow: `.github/workflows/release-marketplace.yml`
 - Trigger: published GitHub release (or manual `workflow_dispatch`)
-- Behavior: fetches `nevalang/neva-tools` (prefers `main`, falls back to `master`), rebuilds `cmd/neva-lsp` for all targets, builds and packages extension, publishes to Marketplace.
+- Behavior: fetches the exact Neva Tools commit recorded in the workflow (unless manually overridden), rebuilds `cmd/neva-lsp` for all targets, builds the shared visual-editor bundle, packages extension, and publishes to Marketplace.
 
 Required secret in GitHub repository settings:
 

--- a/docs/lsp-smoke-checklist.md
+++ b/docs/lsp-smoke-checklist.md
@@ -31,6 +31,7 @@ Open a Neva workspace and verify each feature works end-to-end:
 - document symbols / outline
 - code lens + resolve
 - semantic tokens (declarations/references/ports)
+- `Neva: Open Visual Mode` renders the saved workspace and refreshes after save
 
 ## 3. Issue triage after verification
 

--- a/scripts/release/build-lsp-from-neva-tools.sh
+++ b/scripts/release/build-lsp-from-neva-tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NEVA_DIR="${1:-./neva-lsp}"
+NEVA_DIR="${1:-./neva-tools}"
 OUT_DIR="${2:-./bin}"
 
 if [[ ! -f "$NEVA_DIR/go.mod" ]]; then
@@ -12,14 +12,10 @@ fi
 mkdir -p "$OUT_DIR"
 pushd "$NEVA_DIR" >/dev/null
 
-LSP_ENTRY="./cmd/lsp"
+LSP_ENTRY="./cmd/neva-lsp"
 if [[ ! -d "$LSP_ENTRY" ]]; then
-  if [[ -f "./main.go" ]]; then
-    LSP_ENTRY="."
-  else
-    echo "Unable to locate LSP entrypoint (expected ./cmd/lsp or ./main.go)" >&2
-    exit 1
-  fi
+  echo "Unable to locate LSP entrypoint at $LSP_ENTRY" >&2
+  exit 1
 fi
 
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o "$OUT_DIR/neva-lsp-darwin-amd64" "$LSP_ENTRY"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import {
 } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { setupLsp } from "./lsp";
+import { openVisualEditor } from "./visualEditor";
 
 let lspClient: LanguageClient;
 let runTerminal = undefined as ReturnType<typeof window.createTerminal> | undefined;
@@ -90,12 +91,10 @@ async function setEditorMode(mode: NevaEditorMode) {
   await commands.executeCommand("setContext", nevaEditorModeContextKey, mode);
   onDidChangeEditorModeEmitter.fire(mode);
 
-  if (mode === "visual") {
-    void window.showInformationMessage(
-      "Neva visual mode is not implemented yet. This button is a placeholder for the upcoming visual editor API."
-    );
-  }
+  if (mode === "visual") openVisualEditor(extensionContext, lspClient);
 }
+
+let extensionContext: ExtensionContext;
 
 const runMainCodeLensProvider = {
   provideCodeLenses(
@@ -108,6 +107,7 @@ const runMainCodeLensProvider = {
 
 export async function activate(context: ExtensionContext) {
   console.info("neva module detected, extension activated");
+  extensionContext = context;
 
   // Run language server, initialize client and establish connection
   lspClient = setupLsp(context, process.env.VSCODE_NEVA_DEBUG === "true");

--- a/src/visualEditor.ts
+++ b/src/visualEditor.ts
@@ -1,0 +1,87 @@
+import fs from "fs";
+import path from "path";
+import { ExtensionContext, Uri, ViewColumn, Webview, WebviewPanel, window, workspace } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+
+const viewMethods = new Set([
+  "neva/view/getProgram",
+  "neva/view/getFileView",
+  "neva/view/resolveEntityRef",
+  "neva/view/searchEntities",
+]);
+
+type ViewRequest = {
+  type: "neva/view/request";
+  id: string;
+  method: string;
+  params: unknown;
+};
+
+let panel: WebviewPanel | undefined;
+
+export function openVisualEditor(context: ExtensionContext, client: LanguageClient) {
+  const editor = window.activeTextEditor;
+  if (editor?.document.languageId !== "neva") {
+    window.showErrorMessage("Neva: open a .neva file before opening Visual Mode.");
+    return;
+  }
+
+  if (panel) {
+    panel.reveal(ViewColumn.Beside);
+    return;
+  }
+
+  panel = window.createWebviewPanel("neva.visualEditor", "Neva Visual Mode", ViewColumn.Beside, {
+    enableScripts: true,
+    localResourceRoots: [Uri.file(path.join(context.extensionPath, "dist", "webview"))],
+  });
+  panel.webview.html = getWebviewHtml(context, panel.webview);
+
+  panel.onDidDispose(() => {
+    panel = undefined;
+  }, undefined, context.subscriptions);
+
+  panel.webview.onDidReceiveMessage(async (message: ViewRequest) => {
+    if (message?.type !== "neva/view/request" || typeof message.id !== "string" || !viewMethods.has(message.method)) {
+      return;
+    }
+
+    try {
+      const result = await client.sendRequest(message.method, message.params);
+      await panel?.webview.postMessage({ type: "neva/view/response", id: message.id, result });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await panel?.webview.postMessage({ type: "neva/view/response", id: message.id, error: detail });
+    }
+  }, undefined, context.subscriptions);
+
+  context.subscriptions.push(workspace.onDidSaveTextDocument((document) => {
+    if (document.languageId === "neva") {
+      void panel?.webview.postMessage({ type: "neva/view/refresh" });
+    }
+  }));
+}
+
+function getWebviewHtml(context: ExtensionContext, webview: Webview): string {
+  const root = Uri.file(path.join(context.extensionPath, "dist", "webview"));
+  const indexPath = path.join(root.fsPath, "index.html");
+  if (!fs.existsSync(indexPath)) {
+    return "<h1>Neva Visual Mode is unavailable</h1><p>Reinstall the extension; its visual-editor bundle is missing.</p>";
+  }
+
+  const nonce = String(Date.now());
+  const csp = [
+    "default-src 'none'",
+    `style-src ${webview.cspSource} 'unsafe-inline'`,
+    `script-src 'nonce-${nonce}'`,
+    `img-src ${webview.cspSource} https: data:`,
+    `font-src ${webview.cspSource}`,
+  ].join("; ");
+
+  return fs.readFileSync(indexPath, "utf8")
+    .replace("<head>", `<head><meta http-equiv="Content-Security-Policy" content="${csp}">`)
+    .replace(/(src|href)="\.\/assets\/([^\"]+)"/g, (_match, attribute, asset) => {
+      return `${attribute}="${webview.asWebviewUri(Uri.file(path.join(root.fsPath, "assets", asset)))}"`;
+    })
+    .replace(/<script type="module"/g, `<script nonce="${nonce}" type="module"`);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "skipLibCheck": true,
     "esModuleInterop": true
   },
-  "exclude": ["node_modules", ".vscode-test", "webview"]
+  "exclude": ["node_modules", ".vscode-test", "webview", "neva-tools"]
 }


### PR DESCRIPTION
## What changed

- switches CI and Marketplace release checkout from `nevalang/neva-lsp` to `nevalang/neva-tools`
- builds the explicit `./cmd/neva-lsp` entry point for every target
- renames the release helper to `build-lsp-from-neva-tools.sh`
- updates contributor and repository guidance to the renamed repository

## Why

Neva Tools now owns both `neva-lsp` and `neva-view`; the LSP implementation is no longer at the module root. Without this change, VS Code CI and Marketplace releases would either fetch the stale repository name or fail to find an entry point.

## Validation

- parsed both workflow YAML files
- `bash -n scripts/release/build-lsp-from-neva-tools.sh`
- cross-built `cmd/neva-lsp` for darwin amd64/arm64, linux amd64/arm64/loong64, and windows amd64/arm64 using the updated helper/entry point