### PR TITLE
Lock VS Code builds to Neva Tools releases

### DIFF
--- a/.github/neva-tools.lock
+++ b/.github/neva-tools.lock
@@ -1,0 +1,3 @@
+# Human release identity and immutable source identity must move together.
+NEVA_TOOLS_VERSION=v0.1.0
+NEVA_TOOLS_COMMIT=fda3f771f370688c9ce877f233c3a1988bd52409

--- a/.github/scripts/resolve-neva-tools-lock.sh
+++ b/.github/scripts/resolve-neva-tools-lock.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+override="${1:-}"
+if [[ -n "$override" ]]; then
+  echo "ref=$override" >> "$GITHUB_OUTPUT"
+  echo "version=manual override" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# shellcheck source=/dev/null
+source .github/neva-tools.lock
+repo="https://github.com/nevalang/neva-tools"
+
+# Support both annotated and lightweight tags, but build from the immutable
+# commit only. This detects an accidental or malicious tag move before build.
+tag_commit="$(git ls-remote "$repo" "refs/tags/${NEVA_TOOLS_VERSION}^{}" | awk 'NR == 1 { print $1 }')"
+if [[ -z "$tag_commit" ]]; then
+  tag_commit="$(git ls-remote "$repo" "refs/tags/${NEVA_TOOLS_VERSION}" | awk 'NR == 1 { print $1 }')"
+fi
+
+if [[ "$tag_commit" != "$NEVA_TOOLS_COMMIT" ]]; then
+  echo "Neva Tools lock mismatch: ${NEVA_TOOLS_VERSION} resolves to ${tag_commit:-nothing}, expected ${NEVA_TOOLS_COMMIT}" >&2
+  exit 1
+fi
+
+echo "ref=$NEVA_TOOLS_COMMIT" >> "$GITHUB_OUTPUT"
+echo "version=$NEVA_TOOLS_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ concurrency:
 
 env:
   NODE_VERSION: "20"
-  NEVA_TOOLS_REF: 7e66e889bc1e255dc941d98697cf58365db10cc3
 
 jobs:
   build-lsp-binaries:
@@ -58,26 +57,22 @@ jobs:
       - name: Checkout extension repository
         uses: actions/checkout@v4
 
-      - name: Resolve Neva Tools ref
-        id: neva-ref
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.neva_ref }}" ]; then
-            echo "value=${{ github.event.inputs.neva_ref }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${NEVA_TOOLS_REF}" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Resolve and validate Neva Tools lock
+        id: neva-tools
+        run: bash .github/scripts/resolve-neva-tools-lock.sh "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.neva_ref || '' }}"
 
       - name: Checkout nevalang/neva-tools
         uses: actions/checkout@v4
         with:
           repository: nevalang/neva-tools
-          ref: ${{ steps.neva-ref.outputs.value }}
+          ref: ${{ steps.neva-tools.outputs.ref }}
           path: neva-src
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: neva-src/go.mod
+          cache-dependency-path: neva-src/go.sum
 
       - name: Build LSP binary
         run: |
@@ -104,6 +99,10 @@ jobs:
       - name: Checkout extension repository
         uses: actions/checkout@v4
 
+      - name: Resolve and validate Neva Tools lock
+        id: neva-tools
+        run: bash .github/scripts/resolve-neva-tools-lock.sh "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.neva_ref || '' }}"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -114,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: nevalang/neva-tools
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.neva_ref || env.NEVA_TOOLS_REF }}
+          ref: ${{ steps.neva-tools.outputs.ref }}
           path: neva-tools
 
       - name: Build shared visual-editor WebView bundle

--- a/.github/workflows/release-marketplace.yml
+++ b/.github/workflows/release-marketplace.yml
@@ -17,9 +17,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  NEVA_TOOLS_REF: 7e66e889bc1e255dc941d98697cf58365db10cc3
-
 jobs:
   publish-marketplace:
     runs-on: ubuntu-latest
@@ -35,26 +32,22 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Resolve Neva Tools ref
-        id: neva-ref
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.neva_ref }}" ]; then
-            echo "value=${{ github.event.inputs.neva_ref }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${NEVA_TOOLS_REF}" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Resolve and validate Neva Tools lock
+        id: neva-tools
+        run: bash .github/scripts/resolve-neva-tools-lock.sh "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.neva_ref || '' }}"
 
       - name: Checkout neva-tools
         uses: actions/checkout@v4
         with:
           repository: nevalang/neva-tools
-          ref: ${{ steps.neva-ref.outputs.value }}
+          ref: ${{ steps.neva-tools.outputs.ref }}
           path: neva-tools
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: neva-tools/go.mod
+          cache-dependency-path: neva-tools/go.sum
 
       - name: Build shared visual-editor WebView bundle
         working-directory: neva-tools/web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Follow these instructions when working in this repository.
 
 1. Use `gh` CLI for GitHub context (issues/PRs). Fall back to web browsing only when `gh` is insufficient.
 2. Prefer small, incremental changes. After each feature implementation, report back with what changed and how to verify.
-3. Do **not** push to `main` or release a new extension version without explicit approval.
-4. The Neva compiler lives in `/Users/emil/projects/neva` (read-only). Neva tools live in `nevalang/neva-tools`; source the LSP from its remote `main` when updating binaries.
+3. Do **not** push to `main` or release a new extension version without explicit approval. Open pull requests ready for review by default; use draft only when there is a stated blocker. CI runs for both states.
+4. The Neva compiler lives in `/Users/emil/projects/neva` (read-only). Neva tools live in `nevalang/neva-tools`; use the checked-in `.github/neva-tools.lock` when updating bundled binaries or the visual-editor bundle.
 5. Assume the current Neva language is `main` (ahead of v0.34); deferred connections are **not** supported and should not be encoded in the extension (syntax highlighting, docs, etc.).
 6. Keep the extension compatible with VS Code stable.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The repository includes automated publishing on GitHub Release:
 
 - Workflow: `.github/workflows/release-marketplace.yml`
 - Trigger: published GitHub release (or manual `workflow_dispatch`)
-- Behavior: fetches the exact Neva Tools commit recorded in the workflow (unless manually overridden), rebuilds `cmd/neva-lsp` for all targets, builds the shared visual-editor bundle, packages extension, and publishes to Marketplace.
+- Behavior: validates the checked-in Neva Tools release-and-commit lock (unless manually overridden), rebuilds `cmd/neva-lsp` for all targets, builds the shared visual-editor bundle, packages extension, and publishes to Marketplace.
 
 Required secret in GitHub repository settings:
 


### PR DESCRIPTION
## What changed
- Adds a reviewed Neva Tools release lock with both version and immutable commit.
- Validates that the release tag still resolves to the locked commit before CI or Marketplace builds.
- Builds from the SHA after validation; manual workflow overrides remain possible.
- Documents the ready-for-review PR policy and lock update source.

## Why
A release tag is readable but may be moved; a SHA is reproducible but opaque. The lock makes both identities explicit and prevents silent tag drift.

## Validation
- `bash -n .github/scripts/resolve-neva-tools-lock.sh`
- Executed the lock resolver against `nevalang/neva-tools` v0.1.0
- Parsed both workflow YAML files
- `npm run build`