### PR TITLE
Release VS Code extension v0.7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Release flow:
 
 ## Release Notes
 
+### 0.7.10
+
+- Updated the bundled LSP to `lsp/v0.1.2` with diagnostics for unsaved edits.
+- Kept completion, navigation, semantic tokens and CodeLens available while an
+  unsaved compiler error is displayed.
+- Added a daily-driver Extension Host contract covering diagnostics, language
+  features, Run and packaged Visual Mode; release packaging is verified in a
+  separate CI job.
+
 ### 0.7.9
 
 - Updated bundled `neva-lsp` binaries to use Neva workspace indexing that does not require a `Main` package in module root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-nevalang",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-nevalang",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "description": "VSCode extension for Neva programming language",
   "publisher": "nevalang",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "license": "MIT",
   "engines": {
     "vscode": "^1.78.0"


### PR DESCRIPTION
## Release contents

- lock extension packaging to `lsp/v0.1.2`
- publish unsaved-editor diagnostics while retaining the previous valid language index
- add and pass the daily-driver Extension Host contract

## Verification

- `npm run build`
- current `main` Daily-driver contract and Package VSIX are green
- this PR reruns both gates before publishing

After merge, tag `v0.7.10` and GitHub Release trigger the existing Marketplace workflow.