### PR TITLE
Rename daily-driver integration contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ env:
   NODE_VERSION: '20'
 
 jobs:
-  daily-driver-contract:
-    name: Daily-driver contract
+  extension-integration-contract:
+    name: Extension integration contract
     runs-on: ubuntu-latest
     steps:
       - name: Checkout extension repository
@@ -54,8 +54,8 @@ jobs:
       - name: Build extension
         run: npm run build
 
-      - name: Run extension integration smoke tests
-        run: xvfb-run -a npm run test:integration
+      - name: Run Extension Host integration contract
+        run: xvfb-run -a npm run test:extension-integration
 
   package-vsix:
     name: Package VSIX

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Follow these instructions when working in this repository.
 
 - Typecheck + bundle: `npm run build`
 - Regenerate TextMate grammar: `npm run build:syntax`
-- Daily-driver Extension Host contract: `npm run test:daily-driver`. It covers
+- Extension Host integration contract: `npm run test:extension-integration`. It covers
   diagnostics, language providers, semantic tokens, Run, Visual Mode opening
   and the packaged WebView boundary; use the manual smoke checklist for visual
   rendering and save-to-refresh on a real workspace.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Release flow:
 - Updated the bundled LSP to `lsp/v0.1.2` with diagnostics for unsaved edits.
 - Kept completion, navigation, semantic tokens and CodeLens available while an
   unsaved compiler error is displayed.
-- Added a daily-driver Extension Host contract covering diagnostics, language
+- Added an Extension Host integration contract covering diagnostics, language
   features, Run and packaged Visual Mode; release packaging is verified in a
   separate CI job.
 

--- a/docs/lsp-smoke-checklist.md
+++ b/docs/lsp-smoke-checklist.md
@@ -1,6 +1,6 @@
 # Neva LSP Smoke Checklist
 
-Use this checklist before publishing a new extension version that bundles updated Neva language-server binaries. The automated daily-driver contract is the release gate; this document covers the remaining visual/manual checks.
+Use this checklist before publishing a new extension version that bundles updated Neva language-server binaries. The automated Extension Host integration contract is the release gate; this document covers the remaining visual/manual checks.
 
 ## 1. Bundle check
 
@@ -16,7 +16,7 @@ Use this checklist before publishing a new extension version that bundles update
 
 ```bash
 npm run check:lsp-binaries
-npm run test:integration
+npm run test:extension-integration
 ```
 
 ## 2. Feature smoke test in VS Code

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "build:syntax": "js-yaml syntaxes/neva.tmLanguage.yml > syntaxes/neva.tmLanguage.json",
     "build": "npm-run-all build:*",
     "test:integration": "node ./test/integration/runTest.js",
-    "test:daily-driver": "npm run test:integration",
+    "test:extension-integration": "npm run test:integration",
     "test": "npm run build && npm run test:integration",
     "package:vsix": "npx -y @vscode/vsce@2.24.0 package",
     "publish:openvsx": "npx -y ovsx@0.8.1 publish -p $OPEN_VSX_TOKEN",

--- a/test/integration/suite/extension-integration-contract.test.js
+++ b/test/integration/suite/extension-integration-contract.test.js
@@ -34,7 +34,7 @@ function completionItems(result) {
   return Array.isArray(result) ? result : result?.items || [];
 }
 
-suite('Neva daily-driver contract', () => {
+suite('Neva Extension Host integration contract', () => {
   let extension;
   let api;
   let mainDocument;


### PR DESCRIPTION
## Summary
- rename the ambiguous daily-driver terminology to Extension integration contract
- expose the test as `npm run test:extension-integration`
- align CI check names, test suite name, release notes and release checklist

## Verification
- `npm run test:extension-integration`
- `git diff --check`

No runtime behavior, extension version, tags, releases, or Marketplace artifacts changed.